### PR TITLE
Update README for NodeJS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ const client = new HyperionStreamClient(ENDPOINT, {async: false});
 Example:
 ```javascript
 const client = new HyperionStreamClient('https://example.com', {async: false});
+
+// NodeJS
+const fetch = require("node-fetch");
+const client = new HyperionStreamClient('https://example.com', {async: false, fetch: fetch});
 ```
 
 `https://example.com` is the host, from where `https://example.com/v2/history/...` is served.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ For other usages the bundle is also available at `dist/bundle.js`
 Setup the endpoint that you want to fetch data from and the flow control mode:
 
 ```javascript
-const client = new HyperionStreamClient(ENDPOINT, {async: false});
+const client = new HyperionStreamClient(ENDPOINT, HYPERION_CLIENT_OPTIONS);
 ```
+**HYPERION_CLIENT_OPTIONS** can be found in `src/interfaces.ts`
 
 Example:
 ```javascript


### PR DESCRIPTION
Had some trouble setting up the client for NodeJS and didn't see this **fetch** parameter anywhere in the documentation. 

So I just added it to the README.